### PR TITLE
fix: issue with large package size

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,5 @@ updates:
     assignees:
       - Author
     versioning-strategy: increase
+    commit-message:
+      prefix: "chore(deps)"

--- a/OLD_CHANGELOG.md
+++ b/OLD_CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+This is not used anymore. See GitHub releases for changes.
+
+---
+
 All notable changes to this project will be documented in this file.
 
 ## [1.4.2] - 2024-08-02
@@ -141,9 +145,9 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - New services:
-  - Water alarm
-  - Air purity
-  - Motion lights
+    - Water alarm
+    - Air purity
+    - Motion lights
 
 ### Changed
 

--- a/package.json
+++ b/package.json
@@ -78,5 +78,10 @@
     "ts-node": "10.9.2",
     "typescript": "5.7.3"
   },
+  "files": [
+    "package.json",
+    "LICENSE",
+    "dist"
+  ],
   "packageManager": "yarn@4.6.0"
 }


### PR DESCRIPTION
Due to the latest changes the package contained
also the coverage report, which is not necessary.
This is removed in the pr.
Furthermore, adjust the dependabot naming
strategy.